### PR TITLE
Update JSON format to list of problem items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 To download a test:
 
-`python aops_downloader.py {year} {test （8,10A,10B,12A,12B)} --output {name}.json`
+`python aops_downloader.py {year} {contest (8,10A,10B,12A,12B)} --output {name}.json`
+
+The JSON output is a list of objects with keys `ID`, `Year`, `ProblemNumber`,
+`QuestionType`, `Question`, `Answer` and `Solution`.
 
 To render a test into HTML format:
 
-`python renderer.py {file.json} {output_dir}`
+`python renderer.py json {file.json} {output_dir}`

--- a/aops_downloader.py
+++ b/aops_downloader.py
@@ -84,8 +84,16 @@ def parse_solutions(wikitext: str) -> str:
     return "\n\n".join(filter(None, solutions))
 
 
-def download_contest(year: str | int, contest: str) -> Dict[str, Dict[str, Any]]:
-    """Download contest problems, answers, and solutions from AoPS."""
+from typing import List
+
+
+def download_contest(year: str | int, contest: str) -> List[Dict[str, Any]]:
+    """Download contest problems, answers, and solutions from AoPS.
+
+    The returned structure is a list where each item contains the fields:
+    ``ID``, ``Year``, ``ProblemNumber``, ``QuestionType``, ``Question``,
+    ``Answer`` and ``Solution``.
+    """
     year_str = str(year)
 
     # Download main contest page with all problems
@@ -98,20 +106,22 @@ def download_contest(year: str | int, contest: str) -> Dict[str, Dict[str, Any]]
     answers_text = fetch_page_wikitext(answer_title)
     answers = parse_answers(answers_text)
 
-    result: Dict[str, Dict[str, Any]] = {}
-    for number, question in problems.items():
+    result: List[Dict[str, Any]] = []
+    for number in sorted(problems):
+        question = problems[number]
         problem_page = f"{year_str} AMC {contest} Problems/Problem {number}"
         sol_text = fetch_page_wikitext(problem_page)
         solution = parse_solutions(sol_text)
         pid = f"{year_str}-{contest}-{number}"
-        result[pid] = {
+        result.append({
             "ID": pid,
             "Year": year_str,
-            "Problem Number": number,
+            "ProblemNumber": number,
+            "QuestionType": "choice",
             "Question": question,
             "Answer": answers.get(number, ""),
             "Solution": solution,
-        }
+        })
     return result
 
 

--- a/renderer.py
+++ b/renderer.py
@@ -90,12 +90,13 @@ def render_json(json_file: str, output_dir: str) -> None:
     with open(json_file, "r", encoding="utf-8") as f:
         problems = json.load(f)
 
-    # Sort by problem number for combined page
-    sorted_ids = sorted(problems, key=lambda k: problems[k]["Problem Number"])
+    # Sort items by problem number for combined page
+    sorted_items = sorted(problems, key=lambda d: d["ProblemNumber"])
 
     all_sections: list[str] = []
-    for pid in sorted_ids:
-        data = problems[pid]
+    for item in sorted_items:
+        pid = item["ID"]
+        data = item
         q_html = render_wikitext(data["Question"])
         ans_html = (
             f"<p><strong>Answer:</strong> {data['Answer']}</p>" if data.get("Answer") else ""
@@ -109,7 +110,7 @@ def render_json(json_file: str, output_dir: str) -> None:
         page = f"<html><head>{MATHJAX_SCRIPT}</head><body>\n{body}\n</body></html>"
         out_path = Path(output_dir) / f"{pid}.html"
         out_path.write_text(page, encoding="utf-8")
-        all_sections.append(f"<h2>Problem {data['Problem Number']}</h2>\n{q_html}")
+        all_sections.append(f"<h2>Problem {data['ProblemNumber']}</h2>\n{q_html}")
 
     index = (
         f"<html><head>{MATHJAX_SCRIPT}</head><body>\n"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -28,8 +28,16 @@ def test_parsers_and_download():
     assert "Video Solution" not in solution
 
     data = download_contest("2025", "8")
-    first = data["2025-8-1"]
+    assert isinstance(data, list)
+    required_keys = {"ID", "Year", "ProblemNumber", "QuestionType", "Question", "Answer", "Solution"}
+    for item in data:
+        assert set(item.keys()) == required_keys
+        assert isinstance(item["ProblemNumber"], int)
+        assert isinstance(item["QuestionType"], str)
+    first = next(item for item in data if item["ID"] == "2025-8-1")
     assert first["ID"] == "2025-8-1"
+    assert first["ProblemNumber"] == 1
+    assert first["QuestionType"] == "choice"
     assert first["Answer"] in "ABCDE"
     assert "Video Solution" not in first["Solution"]
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -26,10 +26,16 @@ skip_render = pytest.mark.skipif(not (pandoc_exists and asy_exists), reason="ren
 @skip_render
 def test_render_json(tmp_path):
     problems = download_contest("2025", "8")
-    subset = {pid: problems[pid] for pid in ("2025-8-1", "2025-8-5")}
+    subset = [p for p in problems if p["ID"] in ("2025-8-1", "2025-8-5")]
     json_path = tmp_path / "problems.json"
     with open(json_path, "w", encoding="utf-8") as f:
         json.dump(subset, f, ensure_ascii=False)
+
+    # verify json structure
+    with open(json_path, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert isinstance(saved, list)
+    assert all("ID" in item for item in saved)
 
     render_json(str(json_path), str(tmp_path))
 
@@ -48,7 +54,8 @@ def test_render_json(tmp_path):
 @skip_render
 def test_render_wikitext_asy():
     problems = download_contest("2025", "8")
-    html = render_wikitext(problems["2025-8-5"]["Question"])
+    q = next(item["Question"] for item in problems if item["ID"] == "2025-8-5")
+    html = render_wikitext(q)
     assert "data:image/svg+xml;base64" in html
 
 


### PR DESCRIPTION
## Summary
- adjust `download_contest` to output a list instead of a dict
- update renderer to read list-based JSON
- update README with new JSON structure
- update tests for new structure and verify JSON validity

## Testing
- `pip install requests pypandoc pillow mwparserfromhell`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3ad60d50832190cd62034664746f