### PR TITLE
Handle AoPS redirects in downloader

### DIFF
--- a/aops_downloader.py
+++ b/aops_downloader.py
@@ -13,6 +13,7 @@ def fetch_page_wikitext(page_title: str) -> str:
         "prop": "revisions",
         "rvprop": "content",
         "rvslots": "main",
+        "redirects": 1,
         "format": "json",
     }
     response = requests.get(API_URL, params=params, timeout=30)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -41,3 +41,11 @@ def test_parsers_and_download():
     assert first["Answer"] in "ABCDE"
     assert "Video Solution" not in first["Solution"]
 
+
+def test_redirect_page():
+    text = fetch_page_wikitext("2023 AMC 10A Problems/Problem 5")
+    # should automatically follow redirect
+    assert "#redirect" not in text.lower()
+    solution = parse_solutions(text)
+    assert solution
+


### PR DESCRIPTION
## Summary
- handle wiki redirects when downloading pages
- test redirect handling on AMC 2023 problem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a40438f388321a8dacb2635620031