### PR TITLE
Add AIME/AHSME support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
-To download a test:
+To download a single contest:
 
-`python aops_downloader.py {year} {contest (8,10A,10B,12A,12B)} --output {name}.json`
+```
+python aops_downloader.py {year} {contest} --output {name}.json
+```
+
+`{contest}` may be an AMC contest (e.g. `8`, `10A`, `12B`), an AIME contest
+(e.g. `AIME I`, `AIME II`, or `AIME` for years prior to 2000), or `AHSME`.
 
 The JSON output is a list of objects with keys `ID`, `Year`, `ProblemNumber`,
 `QuestionType`, `Question`, `Answer` and `Solution`.
 
 To render a test into HTML format:
 
-`python renderer.py json {file.json} {output_dir}`
+```
+python renderer.py json {file.json} {output_dir}
+```
+
+To download many contests automatically run:
+
+```
+python automated.py
+```
+
+Results are saved under `amc_problems/`, `aime_problems/`, and
+`ahsme_problems/` depending on contest type.

--- a/aops_downloader.py
+++ b/aops_downloader.py
@@ -59,16 +59,22 @@ def parse_problems(wikitext: str) -> Dict[int, str]:
     return problems
 
 
-_ANSWER_RE = re.compile(r"^#\s*([A-E])\b", re.MULTILINE)
+_ANSWER_RE = re.compile(r"^#\s*([A-E]|\d{1,3})\b", re.MULTILINE)
 
 
 def parse_answers(wikitext: str) -> Dict[int, str]:
-    """Parse answer key wikitext and return mapping from problem number to answer letter."""
+    """Parse answer key wikitext and return mapping from problem number to answer string.
+
+    Answers may be single letters (A-E) for AMC/AHSME contests or numeric
+    values for AIME contests.
+    """
     answers: Dict[int, str] = {}
-    for i, line in enumerate(wikitext.splitlines(), start=1):
+    idx = 1
+    for line in wikitext.splitlines():
         m = _ANSWER_RE.match(line.strip())
         if m:
-            answers[i] = m.group(1)
+            answers[idx] = m.group(1)
+            idx += 1
     return answers
 
 
@@ -99,23 +105,32 @@ def download_contest(year: str | int, contest: str) -> List[Dict[str, Any]]:
     """
     year_str = str(year)
 
+    # Determine base wiki page prefix based on contest type
+    contest_clean = contest.strip()
+    if contest_clean.upper().startswith("AIME"):
+        base = f"{year_str} {contest_clean}"
+    elif contest_clean.upper() == "AHSME":
+        base = f"{year_str} AHSME"
+    else:
+        base = f"{year_str} AMC {contest_clean}"
+
     # Download main contest page with all problems
     print("Fetching problems for", year_str, contest)
-    problems_title = f"{year_str} AMC {contest} Problems"
+    problems_title = f"{base} Problems"
     problems_text = fetch_page_wikitext(problems_title)
     problems = parse_problems(problems_text)
 
     # Download answer key
     print("Fetching answers for", year_str, contest)
-    answer_title = f"{year_str} AMC {contest} Answer Key"
+    answer_title = f"{base} Answer Key"
     answers_text = fetch_page_wikitext(answer_title)
     answers = parse_answers(answers_text)
 
     result: List[Dict[str, Any]] = []
     for number in sorted(problems):
-        print(f"Processing problem {number} for {year_str} AMC {contest}")
+        print(f"Processing problem {number} for {year_str} {contest}")
         question = problems[number]
-        problem_page = f"{year_str} AMC {contest} Problems/Problem {number}"
+        problem_page = f"{base} Problems/Problem {number}"
         sol_text = fetch_page_wikitext(problem_page)
         solution = parse_solutions(sol_text)
         pid = f"{year_str}-{contest}-{number}"
@@ -137,10 +152,13 @@ if __name__ == "__main__":
     import argparse
     import json
 
-    parser = argparse.ArgumentParser(description="Download AMC problems from AoPS")
+    parser = argparse.ArgumentParser(
+        description="Download AMC, AIME, or AHSME problems from AoPS"
+    )
     parser.add_argument("year", help="Contest year")
     parser.add_argument(
-        "contest", help="Contest name, e.g. '8', '10A', '10B', '12A', '12B'"
+        "contest",
+        help="Contest name, e.g. '8', '10A', '10B', '12A', '12B', 'AIME I', 'AHSME'",
     )
     parser.add_argument("--output", help="Output JSON file")
 

--- a/aops_downloader.py
+++ b/aops_downloader.py
@@ -107,7 +107,8 @@ def download_contest(year: str | int, contest: str) -> List[Dict[str, Any]]:
 
     # Determine base wiki page prefix based on contest type
     contest_clean = contest.strip()
-    if contest_clean.upper().startswith("AIME"):
+    is_aime = contest_clean.upper().startswith("AIME")
+    if is_aime:
         base = f"{year_str} {contest_clean}"
     elif contest_clean.upper() == "AHSME":
         base = f"{year_str} AHSME"
@@ -139,7 +140,7 @@ def download_contest(year: str | int, contest: str) -> List[Dict[str, Any]]:
                 "ID": pid,
                 "Year": year_str,
                 "ProblemNumber": number,
-                "QuestionType": "choice",
+                "QuestionType": "int3" if is_aime else "choice",
                 "Question": question,
                 "Answer": answers.get(number, ""),
                 "Solution": solution,

--- a/automated.py
+++ b/automated.py
@@ -17,13 +17,19 @@ def resume_download():
     for year in years:
         year_int = int(str(year).split()[0])
         contests_available = (
-            ["10A", "10B", "12A", "12B"]
+            []
+            if year_int <= 2001
+            else ["10A", "10B", "12A", "12B"]
             if "2021" in year
             else ["8"]
             if "2025" in year
             else contests
         )
-        aime = ["AIME I", "AIME II"] if year_int >= 2000 else ["AIME"]
+        aime = (
+            []
+            if "Fall" in year
+            else (["AIME I", "AIME II"] if year_int >= 2000 else ["AIME"])
+        )
         contests_available = list(contests_available) + aime
         if year_int <= 1999:
             contests_available.append("AHSME")
@@ -55,9 +61,7 @@ def resume_download():
                     print(f"Saved to {output_file}")
                     done = True
             else:
-                print(
-                    f"Already downloaded {year} {contest} problems. Skipping..."
-                )
+                print(f"Already downloaded {year} {contest} problems. Skipping...")
 
 
 if __name__ == "__main__":

--- a/automated.py
+++ b/automated.py
@@ -5,14 +5,17 @@ from aops_downloader import download_contest
 import os
 import json
 
-years = reversed(list(map(str, range(2002, 2026))) + ["2021 Fall"])
+years = reversed(list(map(str, range(1983, 2026))) + ["2021 Fall"])
 contests = ["8", "10A", "10B", "12A", "12B"]
 
-save_dir = "amc_problems"
+amc_dir = "amc_problems"
+aime_dir = "aime_problems"
+ahsme_dir = "ahsme_problems"
 
 
 def resume_download():
     for year in years:
+        year_int = int(str(year).split()[0])
         contests_available = (
             ["10A", "10B", "12A", "12B"]
             if "2021" in year
@@ -20,18 +23,31 @@ def resume_download():
             if "2025" in year
             else contests
         )
+        aime = ["AIME I", "AIME II"] if year_int >= 2000 else ["AIME"]
+        contests_available = list(contests_available) + aime
+        if year_int <= 1999:
+            contests_available.append("AHSME")
+
         for contest in contests_available:
-            contest_dir = os.path.join(save_dir, f"{contest}")
+            c_upper = contest.upper()
+            if c_upper.startswith("AIME"):
+                base_dir = aime_dir
+            elif c_upper == "AHSME":
+                base_dir = ahsme_dir
+            else:
+                base_dir = amc_dir
+
+            contest_dir = os.path.join(base_dir, contest)
             os.makedirs(contest_dir, exist_ok=True)
             output_file = os.path.join(contest_dir, f"{year}-{contest}.json")
             if not os.path.exists(output_file):
                 done = False
                 while not done:
-                    print(f"Downloading {year} AMC {contest} problems...")
+                    print(f"Downloading {year} {contest} problems...")
                     try:
                         problems = download_contest(year, contest)
                     except Exception as e:
-                        print(f"Error downloading {year} AMC {contest}: {e}")
+                        print(f"Error downloading {year} {contest}: {e}")
                         time.sleep(61)
                         continue
                     with open(output_file, "w", encoding="utf-8") as f:
@@ -39,11 +55,13 @@ def resume_download():
                     print(f"Saved to {output_file}")
                     done = True
             else:
-                print(f"Already downloaded {year} AMC {contest} problems. Skipping...")
+                print(
+                    f"Already downloaded {year} {contest} problems. Skipping..."
+                )
 
 
 if __name__ == "__main__":
-    if not os.path.exists(save_dir):
-        os.makedirs(save_dir)
+    for d in (amc_dir, aime_dir, ahsme_dir):
+        os.makedirs(d, exist_ok=True)
     resume_download()
     print("All downloads completed.")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -56,3 +56,31 @@ def test_redirect_page():
     assert "#redirect" not in text.lower()
     solution = parse_solutions(text)
     assert solution
+
+
+def test_aime_and_ahsme():
+    # AIME without I/II (1998)
+    aime_text = fetch_page_wikitext("1998 AIME Problems")
+    aime_problems = parse_problems(aime_text)
+    assert 1 in aime_problems and 15 in aime_problems
+
+    aime_ans_text = fetch_page_wikitext("1998 AIME Answer Key")
+    aime_answers = parse_answers(aime_ans_text)
+    assert aime_answers[1].isdigit()
+
+    aime_data = download_contest("1998", "AIME")
+    first = next(item for item in aime_data if item["ProblemNumber"] == 1)
+    assert first["Answer"].isdigit()
+
+    # AHSME (1999)
+    ahsme_text = fetch_page_wikitext("1999 AHSME Problems")
+    ahsme_problems = parse_problems(ahsme_text)
+    assert 1 in ahsme_problems and 30 in ahsme_problems
+
+    ahsme_ans_text = fetch_page_wikitext("1999 AHSME Answer Key")
+    ahsme_answers = parse_answers(ahsme_ans_text)
+    assert ahsme_answers[1] in "ABCDE"
+
+    ahsme_data = download_contest("1999", "AHSME")
+    first_h = next(item for item in ahsme_data if item["ProblemNumber"] == 1)
+    assert first_h["Answer"] in "ABCDE"


### PR DESCRIPTION
## Summary
- extend downloader to support AIME (I, II and pre-2000) and AHSME
- install numeric/letter answer parsing
- enhance automated downloading script for new contests
- test AIME and AHSME downloads
- save AMC/AIME/AHSME to separate directories
- document usage and automated script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbe8e822483218eaec6b2ec5af44b